### PR TITLE
feat: Add WeatherAPIClient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pytest-cov==4.1.0       # Coverage reporting (Target >90%)
 pytest-mock==3.12.0     # API mocking for resilient tests
 ruff==0.2.1             # Fast linting and formatting
 mypy==1.8.0             # Static type checking 
+types-requests
 
 # --- DevOps & Environment ---
 python-dotenv==1.0.1    # Environment variable management

--- a/src/api/weather.py
+++ b/src/api/weather.py
@@ -1,0 +1,74 @@
+# src/api/weather.py
+from typing import Any
+
+import pandas as pd
+import requests
+from loguru import logger
+
+
+class WeatherAPIClient:
+    """Client to fetch daily weather metrics from Open-Meteo (Free)."""
+
+    def __init__(self) -> None:
+        self.logger = logger
+        # No API key needed for Open-Meteo non-commercial use
+        self.base_url = "https://api.open-meteo.com/v1/forecast"
+
+    def fetch_daily_metrics(self, location_name: str, lat: float, lon: float) -> pd.DataFrame:
+        """
+        Fetch weather data and aggregate it into daily metrics.
+
+        Args:
+            location_name: Friendly name (e.g., 'Mato Grosso').
+            lat: Latitude.
+            lon: Longitude.
+        """
+        self.logger.info(f"Fetching Open-Meteo data for {location_name} ({lat}, {lon})")
+
+        params: dict[str, Any] = {
+            "latitude": lat,
+            "longitude": lon,
+            "daily": ["temperature_2m_mean", "precipitation_sum"],
+            "timezone": "auto",
+            "forecast_days": 1,  # We only need the current/recent data
+        }
+
+        try:
+            response = requests.get(self.base_url, params=params, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+
+            if "daily" not in data:
+                self.logger.warning(f"No daily data returned for {location_name}.")
+                return pd.DataFrame()
+
+            # Open-Meteo returns data in a clean dictionary of lists
+            daily_data = data["daily"]
+            df_daily = pd.DataFrame(
+                {
+                    "date": pd.to_datetime(daily_data["time"]).date,
+                    "temp_mean": daily_data["temperature_2m_mean"],
+                    "precip_mm": daily_data["precipitation_sum"],
+                }
+            )
+
+            # Add location and reorder to match WeatherMetrics model
+            df_daily["location"] = location_name
+            df_daily = df_daily[["date", "location", "temp_mean", "precip_mm"]]
+
+            self.logger.info(f"Extracted {len(df_daily)} records for {location_name}")
+            return df_daily
+
+        except requests.RequestException as e:
+            self.logger.error(f"Open-Meteo request failed: {str(e)}")
+            raise
+
+
+if __name__ == "__main__":
+    client = WeatherAPIClient()
+    # Mato Grosso coordinates
+    try:
+        df = client.fetch_daily_metrics("Mato Grosso", -12.5456, -55.7267)
+        print(df.head())
+    except Exception as e:
+        logger.error(f"Manual test failed: {e}")

--- a/tests/unit/test_weather.py
+++ b/tests/unit/test_weather.py
@@ -1,0 +1,32 @@
+# tests/unit/test_weather.py
+import pytest
+from pytest_mock import MockerFixture
+
+from src.api.weather import WeatherAPIClient
+
+
+@pytest.fixture
+def client() -> WeatherAPIClient:
+    return WeatherAPIClient()
+
+
+def test_fetch_weather_success(client: WeatherAPIClient, mocker: MockerFixture) -> None:
+    # Mock the Open-Meteo JSON response structure
+    mock_response = {
+        "daily": {
+            "time": ["2026-02-11"],
+            "temperature_2m_mean": [28.5],
+            "precipitation_sum": [12.4],
+        }
+    }
+
+    mock_get = mocker.patch("src.api.weather.requests.get")
+    mock_get.return_value.json.return_value = mock_response
+    mock_get.return_value.raise_for_status.return_value = None
+
+    df = client.fetch_daily_metrics("Mato Grosso", -12.5, -55.5)
+
+    assert not df.empty
+    assert df.iloc[0]["temp_mean"] == 28.5
+    assert df.iloc[0]["location"] == "Mato Grosso"
+    assert "precip_mm" in df.columns


### PR DESCRIPTION
This pull request introduces a new `WeatherAPIClient` class for fetching daily weather metrics from the Open-Meteo API and adds corresponding unit tests to ensure its correct behavior. The main themes are the implementation of the weather API client and the addition of robust unit testing.

**Weather API Client Implementation:**

* Added a new `WeatherAPIClient` class in `src/api/weather.py` to fetch and aggregate daily weather metrics (mean temperature and precipitation) for a given location using the Open-Meteo API. The class handles API requests, logging, and data transformation into a pandas DataFrame.

**Testing:**

* Introduced a unit test in `tests/unit/test_weather.py` that uses mocking to simulate Open-Meteo API responses, verifying that `WeatherAPIClient.fetch_daily_metrics` correctly processes and returns the expected data structure and values.